### PR TITLE
Claimed interface before accessing USB device

### DIFF
--- a/NucLibUsb.c
+++ b/NucLibUsb.c
@@ -84,6 +84,7 @@ int NUC_OpenUsb(void)
 		libusb_exit(NULL);
 		return -1;
 	}
+	libusb_claim_interface(handle, 0);
 	libusb_reset_device(handle);
 #ifdef _WIN32
 	libusb_set_auto_detach_kernel_driver(handle, 1);


### PR DESCRIPTION
This prevents the kernel from issuing a warning, and seems to fix a
stability issue with VMWare's USB support hanging when NuWriter is first
run.